### PR TITLE
Add server and client scripts for purchase invoice capture

### DIFF
--- a/erpnext/client_scripts/purchase_invoice_capture_disable_submit.js
+++ b/erpnext/client_scripts/purchase_invoice_capture_disable_submit.js
@@ -1,0 +1,8 @@
+// Dieses Client-Script deaktiviert den Submit-Button für 60 Sekunden,
+// nachdem der Benutzer im Bestätigungsdialog auf "Yes" geklickt hat.
+frappe.ui.form.on("Purchase Invoice Capture", {
+	before_submit(frm) {
+		frm.disable_save();
+		setTimeout(() => frm.enable_save(), 60000);
+	},
+});

--- a/erpnext/server_scripts/purchase_invoice_capture_before_submit.py
+++ b/erpnext/server_scripts/purchase_invoice_capture_before_submit.py
@@ -1,0 +1,32 @@
+# ruff: noqa: F821
+
+# Routing key for external validation
+ROUTING_KEY = "Purchase-Invoice-Capture-Validation"
+
+# Prepare payload with required details
+payload = {
+	"docname": doc.name,
+	"submit_after_validate": True,
+	"datetime": frappe.utils.now(),
+	"user": frappe.session.user,
+}
+
+try:
+	frappe.call(
+		"bs24core.api.call_async_n8n_function",
+		routingKey=ROUTING_KEY,
+		jsonparam=frappe.as_json(payload),
+	)
+except Exception as e:
+	frappe.log_error(
+		f"Error sending Purchase Invoice Capture validation for {doc.name}: {e}",
+		"Purchase Invoice Capture Pre Submit",
+	)
+
+frappe.msgprint(
+	"Dokument würd zur Prüfung gesendet und anschließend weiter verarbeitet.",
+	alert=True,
+	indicator="blue",
+)
+
+raise frappe.ValidationError


### PR DESCRIPTION
## Summary
- update server script to send purchase invoice capture validation without imports
- add client script with comment to disable submit for 60 seconds

## Testing
- `ruff format erpnext/server_scripts/purchase_invoice_capture_before_submit.py`
- `ruff check erpnext/server_scripts/purchase_invoice_capture_before_submit.py`
- `npx prettier -w erpnext/client_scripts/purchase_invoice_capture_disable_submit.js`
